### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The state-machine will pull source image uris into your private ECR registry acc
 
 ### Building containers
 
-Note that this process is only necessary if you wish to build containers from scratch rather than simply retreiving them from a public repository. If you don't want to rebuild any containers then you can skip this section and proceed with the ["Confugure and run workflow"](#configure-and-run-workflow) step.
+Note that this process is only necessary if you wish to build containers from scratch rather than simply retreiving them from a public repository as described above.
 
 Create a config file at the root level of this application called `app-config.json` with contents like:
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The state-machine will pull source image uris into your private ECR registry acc
 
 ### Building containers
 
+Note that this process is only necessary if you wish to build containers from scratch rather than simply retreiving them from a public repository. If you don't want to rebuild any containers then you can skip this section and proceed with the ["Confugure and run workflow"](#configure-and-run-workflow) step.
+
 Create a config file at the root level of this application called `app-config.json` with contents like:
 
 ```json


### PR DESCRIPTION
Clarifies that the "Building container images" step is not required unless the user wants to rebuild the images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
