### PR TITLE
Allow cross-account and cross-region pulls from ECR Private

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Create a config file at the root level of this application call `app-config.json
 }
 ```
 
-The `source_aws_accounts` list specifies other AWS account ids that the application is allowed to pull ECR Private images from. Each account id will resolve to a corresponding ECR Private registry in the region that the CDK application is deployed to.
+The `source_aws_accounts` list specifies other AWS account ids that the application is allowed to pull ECR Private images from. By default, each account id will resolve to a corresponding ECR Private registry in the region that the CDK application is deployed to.
 
 For the example above, if the CDK application was deployed to the `us-east-1` AWS region, this would be:
 
@@ -108,6 +108,22 @@ For the example above, if the CDK application was deployed to the `us-east-1` AW
 111122223333.dkr.ecr.us-east-1.amazonaws.com
 444455556666.dkr.ecr.us-east-1.amazonaws.com
 ```
+
+To allow pulling containers across AWS regions, modify the config to be like:
+
+```json
+{
+    "container_puller": {
+        "source_aws_accounts": [
+            "111122223333",
+            "444455556666"
+        ],
+        "allow_cross_region_pull": true
+    }
+}
+```
+
+> **Note**: Cross-region container image pulls are typically slower and may incur additional cost.
 
 (Re)deploy the application using:
 

--- a/bin/omx-ecr-helper.ts
+++ b/bin/omx-ecr-helper.ts
@@ -13,10 +13,23 @@ import * as fs from 'fs';
 // this is simple for now, but if config gets more complex consider using node-config instead
 const app_config = process.env.CDK_APP_CONFIG || 'app-config.json';
 let source_uris: string[] = [];
+let source_aws_accounts: string[] = [];
 try {
   const config = JSON.parse(fs.readFileSync(app_config, 'utf8'));
-  source_uris = config.container_builder.source_uris;
-  console.log('configuration loaded: ' + app_config)
+  console.log('configuration loaded: ' + app_config);
+
+  const has_container_puller_config = config.hasOwnProperty('container_puller');
+  const has_container_builder_config = config.hasOwnProperty('container_builder');
+
+  if (has_container_puller_config) {
+    console.log('container puller config: ' + has_container_puller_config);
+    source_aws_accounts = config.container_puller.source_aws_accounts;
+  }
+
+  if (has_container_builder_config) {
+    console.log('container builder config: ' + has_container_builder_config)
+    source_uris = config.container_builder.source_uris;
+  }
 
 } catch (error) {
   console.log('no configuration file provided. using defaults.')
@@ -30,6 +43,9 @@ new ContainerPullerStack(app, 'OmxEcrHelper-ContainerPuller', {
     account: process.env.CDK_DEFAULT_ACCOUNT, 
     region: process.env.CDK_DEPLOY_REGION || process.env.CDK_DEFAULT_REGION 
   },
+
+  // additional aws accounts that ecr private container images can be retrieved from
+  source_aws_accounts: source_aws_accounts
 
 });
 

--- a/bin/omx-ecr-helper.ts
+++ b/bin/omx-ecr-helper.ts
@@ -14,6 +14,7 @@ import * as fs from 'fs';
 const app_config = process.env.CDK_APP_CONFIG || 'app-config.json';
 let source_uris: string[] = [];
 let source_aws_accounts: string[] = [];
+let allow_cross_region_pull: boolean = false;
 try {
   const config = JSON.parse(fs.readFileSync(app_config, 'utf8'));
   console.log('configuration loaded: ' + app_config);
@@ -24,6 +25,8 @@ try {
   if (has_container_puller_config) {
     console.log('container puller config: ' + has_container_puller_config);
     source_aws_accounts = config.container_puller.source_aws_accounts;
+
+    allow_cross_region_pull = config.container_puller.hasOwnProperty('allow_cross_region_pull') ? config.container_puller.allow_cross_region_pull : allow_cross_region_pull;
   }
 
   if (has_container_builder_config) {
@@ -45,7 +48,8 @@ new ContainerPullerStack(app, 'OmxEcrHelper-ContainerPuller', {
   },
 
   // additional aws accounts that ecr private container images can be retrieved from
-  source_aws_accounts: source_aws_accounts
+  source_aws_accounts: source_aws_accounts,
+  allow_cross_region_pull: allow_cross_region_pull
 
 });
 

--- a/lib/container-puller-stack.ts
+++ b/lib/container-puller-stack.ts
@@ -107,15 +107,15 @@ export class ContainerPullerStack extends cdk.Stack {
                             'REGISTRY=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com',
                             
                             // pull through supported uris
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "true" ]] && echo "Materializing image ... $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG" || true',
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "true" ]] && docker pull $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG || true',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "true" ]]; then echo "Materializing image ... $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG"; fi',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "true" ]]; then docker pull $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG; fi',
 
                             // other uris
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "false" ]] && echo "Retrieving $SOURCE_URI" || true',
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "false" ]] && docker pull $SOURCE_URI || true',
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "false" ]] && echo "Pushing as $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG" || true',
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "false" ]] && docker tag $SOURCE_URI $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG || true',
-                            '[[ "$PULL_THROUGH_SUPPORTED" == "false" ]] && docker push $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG || true',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "false" ]]; then echo "Retrieving $SOURCE_URI"; fi',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "false" ]]; then docker pull $SOURCE_URI; fi',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "false" ]]; then echo "Pushing as $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG"; fi',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "false" ]]; then docker tag $SOURCE_URI $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG; fi',
+                            'if [[ "$PULL_THROUGH_SUPPORTED" == "false" ]]; then docker push $REGISTRY/$ECR_REPO_NAME:$IMAGE_TAG; fi',
 
                         ]
                     }

--- a/lib/container-puller-stack.ts
+++ b/lib/container-puller-stack.ts
@@ -17,7 +17,8 @@ import * as buildTasks from './sfn/build-tasks';
 import * as ecrTasks from './sfn/ecr-tasks';
 
 export interface ContainerPullerStackProps extends cdk.StackProps {
-    source_aws_accounts?: string[]
+    source_aws_accounts?: string[],
+    allow_cross_region_pull?: boolean
 }
 
 export class ContainerPullerStack extends cdk.Stack {
@@ -167,6 +168,7 @@ export class ContainerPullerStack extends cdk.Stack {
         // x-account ecr private access
         // this should be read-only, e.g. only allowed to pull images from other accounts
         if ( props?.source_aws_accounts && props?.source_aws_accounts.length ) {
+            const allowed_region: string = props?.allow_cross_region_pull ? "*" : this.region;
             policy_build_project.addStatements(
                 new iam.PolicyStatement({
                     effect: iam.Effect.ALLOW,
@@ -177,7 +179,7 @@ export class ContainerPullerStack extends cdk.Stack {
                     ],
                     resources: props?.source_aws_accounts.map(accountId => {
                         return cdk.Arn.format(
-                            {account: accountId, service: "ecr", resource: "repository", resourceName: "*"}, 
+                            {account: accountId, region: allowed_region, service: "ecr", resource: "repository", resourceName: "*"}, 
                             this) 
                     })
                 })

--- a/lib/container-puller-stack.ts
+++ b/lib/container-puller-stack.ts
@@ -83,6 +83,9 @@ export class ContainerPullerStack extends cdk.Stack {
                 privileged: true,
                 environmentVariables: {
                     SOURCE_URI: { value: '' }, 
+                    SOURCE_REGISTRY: { value:  '' },
+                    SOURCE_IS_ECR_PRIVATE: { value: '' },
+                    SOURCE_AWS_REGION: { value: '' },
                     IMAGE_TAG: { value: '' },
                     PULL_THROUGH_SUPPORTED: { value: '' },
                     ECR_REPO_NAME: { value: '' },
@@ -99,7 +102,8 @@ export class ContainerPullerStack extends cdk.Stack {
                         commands: [
                             'echo Logging in to Amazon ECR...',
                             'REGISTRY=$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com',
-                            'aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REGISTRY'
+                            'aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $REGISTRY',
+                            'if [[ "$SOURCE_IS_ECR_PRIVATE" == "true" ]]; then aws ecr get-login-password --region $SOURCE_AWS_REGION | docker login --username AWS --password-stdin $SOURCE_REGISTRY; fi',
                         ]
                     },
                     build: {
@@ -168,6 +172,9 @@ export class ContainerPullerStack extends cdk.Stack {
 
         const ProcessImageURI = new buildTasks.BuildContainerTask(this, 'Process Image URI', build_project, {
             SOURCE_URI: { value: sfn.JsonPath.stringAt('$.image.source_uri') },
+            SOURCE_REGISTRY: { value: sfn.JsonPath.stringAt('$.image.source_registry') },
+            SOURCE_IS_ECR_PRIVATE: { value: sfn.JsonPath.stringAt('$.image.source_is_ecr_private') },
+            SOURCE_AWS_REGION: { value: sfn.JsonPath.stringAt('$.image.source_aws_region') },
             IMAGE_TAG: { value: sfn.JsonPath.stringAt('$.image.tag') },
             PULL_THROUGH_SUPPORTED: { value: sfn.JsonPath.stringAt('$.image.pull_through_supported') },
             ECR_REPO_NAME: { value: sfn.JsonPath.stringAt('$.image.ecr_repository') }

--- a/lib/lambda/parse-image-uri/lambda_function.py
+++ b/lib/lambda/parse-image-uri/lambda_function.py
@@ -6,7 +6,7 @@ def is_ecr_private_repo(_registry_name):
     """
     Detect private registry in format <awsaccountid>.dkr.ecr.<awsregion>.amazonaws.com
     """
-    return re.match('[0-9]{12}\.dkr\.ecr\.[a-zA-Z0-9-]{1,}\.amazonaws\.com', _registry_name)
+    return re.match('(?P<RegistryId>[0-9]{12})\.dkr\.ecr\.(?P<AWSRegion>[a-zA-Z0-9-]{1,})\.amazonaws\.com', _registry_name)
     
 def lambda_handler(event, context):
     pprint(event)
@@ -24,12 +24,16 @@ def lambda_handler(event, context):
     with open('public_registry_properties.json', 'r') as f:
         registry_props = json.load(f)
 
+    source_is_ecr_private = False
+    source_aws_region = None
     if registry_props.get(registry_name):
         props = registry_props[registry_name]
         ecr_repo_name = "/".join([props['namespace'], image_name])
-    elif is_ecr_private_repo(registry_name):
+    elif (registry_info:=is_ecr_private_repo(registry_name)):
         props = { "namespace": None, "pull_through": False }
         ecr_repo_name = image_name
+        source_is_ecr_private = True
+        source_aws_region = registry_info.groupdict()['AWSRegion']
     else:
         # unrecognized registry, pass it through
         props = { "namespace": None, "pull_through": False }
@@ -38,6 +42,9 @@ def lambda_handler(event, context):
     return {
         "image": {
             "source_uri": uri,
+            "source_registry": registry_name,
+            "source_is_ecr_private": str(source_is_ecr_private).lower(),
+            "source_aws_region": source_aws_region,
             "target_image": ":".join([ecr_repo_name, tag_name]),
             "ecr_repository": ecr_repo_name,
             "tag": tag_name,


### PR DESCRIPTION
*Description of changes:*
* Fixes logic in CodeBuild `build` phase when pulling containers - should fail on appropriate errors
* Adds ability to pull from ECR Private registries in other accounts and across regions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
