### PR TITLE
fix error if source_aws_region is None/null

### DIFF
--- a/lib/lambda/parse-image-uri/lambda_function.py
+++ b/lib/lambda/parse-image-uri/lambda_function.py
@@ -44,7 +44,7 @@ def lambda_handler(event, context):
             "source_uri": uri,
             "source_registry": registry_name,
             "source_is_ecr_private": str(source_is_ecr_private).lower(),
-            "source_aws_region": source_aws_region,
+            "source_aws_region": str(source_aws_region),
             "target_image": ":".join([ecr_repo_name, tag_name]),
             "ecr_repository": ecr_repo_name,
             "tag": tag_name,


### PR DESCRIPTION
*Description of changes:*
Resolves issue for non-ECR private containers where `source_aws_region` is not populated and results in a `null` JSON input to the "Process Image URI" task of the puller state machine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
